### PR TITLE
Added xcode 7.3 support in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ env:
 matrix:
    include:
        - os: osx
+         osx_image: xcode7.3 # apple-clang 7.3
+         language: generic
+         env:
+       - os: osx
          osx_image: xcode7.1 # apple-clang 7.0
          language: generic
          env:


### PR DESCRIPTION
I suppose that this build will fail until all packages for 7.3 has been uploaded. 
I think libgif has some kind of problem with this new compiler that will require to look at it.
Anyway, this build will allow us to reveal the problems.
