### PR TITLE
Libcurl without apple framework

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,9 @@ class ImageFlowConan(ConanFile):
             self.requires("libcurl/7.47.1@lasote/stable")
             if self.settings.os != "Windows":  # Not supported in windows
                 self.requires("theft/0.2.0@lasote/stable")
+            if self.settings.os == "Macos":
+                self.options["libcurl"].darwin_ssl = False
+                self.options["libcurl"].custom_cacert = True
 
     def imports(self):
         self.copy("*.so", dst="bin", src="bin")  # From bin to bin


### PR DESCRIPTION
- There are two ways to use libcurl with osx, using openssl or the native apple ssl framework
- I have added the options for use conan's openssl
- I you would to use the apple ssl framework you need to add the needed apple frameworks:

```
macro(ADD_FRAMEWORK fwname appname)
    find_library(FRAMEWORK_${fwname}
    NAMES ${fwname}
    PATHS ${CMAKE_OSX_SYSROOT}/System/Library
    PATH_SUFFIXES Frameworks
    NO_DEFAULT_PATH)
    if( ${FRAMEWORK_${fwname}} STREQUAL FRAMEWORK_${fwname}-NOTFOUND)
        MESSAGE(ERROR ": Framework ${fwname} not found")
    else()
        TARGET_LINK_LIBRARIES(${appname} "${FRAMEWORK_${fwname}}/${fwname}")
        MESSAGE(STATUS "Framework ${fwname} found at ${FRAMEWORK_${fwname}}")
    endif()
endmacro(ADD_FRAMEWORK)

if(APPLE)
    ADD_FRAMEWORK(Cocoa main)
    ADD_FRAMEWORK(Security main)
endif()
TARGET_LINK_LIBRARIES(main ${CONAN_LIBS})
```
