### PR TITLE
Some fixes for cargo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,11 @@ option(ENABLE_TEST OFF)
 option(ENABLE_PROFILING OFF)
 option(SKIP_LIBRARY OFF)
 
-if (NOT SKIP_LIBRARY)
-	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/build/conanbuildinfo.cmake)
-		set(ENABLE_TEST ON)
-	endif()
-endif()
+# if (NOT SKIP_LIBRARY)
+#	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/build/conanbuildinfo.cmake)
+#		set(ENABLE_TEST ON)
+#	endif()
+# endif()
 
 list(REMOVE_ITEM CONAN_LIBS efence) # FIXME: Maybe efence should be a private dep of openssls
 
@@ -26,9 +26,12 @@ file(GLOB_RECURSE LIB_SRCS lib/*.c)
 file(GLOB LIB_HDRS lib/*.h)
 list(APPEND LIB_HDRS imageflow.h)
 list(APPEND LIB_HDRS imageflow_advanced.h)
-
+	
 if (NOT SKIP_LIBRARY)
-	add_library(imageflow SHARED ${LIB_SRCS} ${LIB_HDRS})
+	add_library(imageflow ${LIB_SRCS} ${LIB_HDRS})
+	set_target_properties(imageflow PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+	set_target_properties(imageflow PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+   
 	target_link_libraries(imageflow ${CONAN_LIBS})
 	target_include_directories(imageflow PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 	target_compile_options(imageflow PRIVATE "-flto")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT SKIP_LIBRARY)
    
 	target_link_libraries(imageflow ${CONAN_LIBS})
 	target_include_directories(imageflow PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-	target_compile_options(imageflow PRIVATE "-flto")
+	# target_compile_options(imageflow PRIVATE "-flto")
 	target_compile_options(imageflow PRIVATE "-fverbose-asm")
 endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,6 +33,7 @@ class ImageFlowConan(ConanFile):
         self.copy("*.dylib*", dst="bin", src="lib")  # From lib to bin
         self.copy("*cacert.pem", dst="bin")  # Allows use libcurl with https without problems - except on darwin
         self.copy("*cacert.pem", dst=".")  # Allows use libcurl with https without problems
+        self.copy("*.a", dst=".") # Copy all static libs to use in cargo build.
 
     def clean_cmake_cache(self, build_dir):
         def on_build_dir(x):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,12 +1,13 @@
 from conans import ConanFile, CMake
 import os
+import shutil
 
 class ImageFlowConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     requires = "littlecms/2.7@lasote/stable", "libpng/1.6.21@lasote/stable", "libjpeg-turbo/1.4.2@imazen/testing" , "giflib/5.1.3@lasote/stable"
-    options = {"build_tests": [True, False], "profiling": [True, False], "coverage": [True, False]}
+    options = {"shared": [True, False], "build_tests": [True, False], "profiling": [True, False], "coverage": [True, False]}
     generators = "cmake"
-    default_options = "build_tests=True", "coverage=False", "profiling=False", "libjpeg-turbo:shared=False", "libpng:shared=False", \
+    default_options = "shared=False", "build_tests=True", "coverage=False", "profiling=False", "libjpeg-turbo:shared=False", "libpng:shared=False", \
    					  "zlib:shared=False", "libcurl:shared=False", "OpenSSL:shared=True", \
    					  "imageflow:shared=True"
 
@@ -33,18 +34,37 @@ class ImageFlowConan(ConanFile):
         self.copy("*cacert.pem", dst="bin")  # Allows use libcurl with https without problems - except on darwin
         self.copy("*cacert.pem", dst=".")  # Allows use libcurl with https without problems
 
+    def clean_cmake_cache(self, build_dir):
+        def on_build_dir(x):
+            return os.path.join(build_dir, x)
+        
+        try:
+            shutil.rmtree(on_build_dir("CMakeFiles"))
+            os.remove(on_build_dir("CMakeCache.txt"))
+            os.remove(on_build_dir("cmake_install.cmake"))
+            os.remove(on_build_dir("Makefile"))
+        except:
+            pass
+
+
     def build(self):
-        if not os.path.exists("./build"):
-            os.mkdir("./build")
-        os.chdir("./build")
+        build_dir = os.path.join(self.conanfile_directory, "build")
+        if not os.path.exists(build_dir):
+            os.mkdir(build_dir)
+        else:
+            self.clean_cmake_cache(build_dir)
+        os.chdir(build_dir)
         cmake = CMake(self.settings)
         cmake_settings = ""
+
         if self.options.coverage:
             cmake_settings += " -DCOVERAGE=ON"
         if self.options.build_tests:
             cmake_settings += " -DENABLE_TEST=ON"
         if self.options.profiling:
             cmake_settings += " -DSKIP_LIBRARY=ON -DENABLE_TEST=OFF -DENABLE_PROFILING=ON"
+        
+        cmake_settings += " -DBUILD_SHARED_LIBS=ON" if self.options.shared else " -DBUILD_SHARED_LIBS=OFF"
 
         cmake_command = 'cmake "%s" %s %s' % (self.conanfile_directory, cmake.command_line, cmake_settings)
         cmake_build_command = 'cmake --build . %s' % cmake.build_config

--- a/wrappers/server/build.rs
+++ b/wrappers/server/build.rs
@@ -23,4 +23,11 @@ fn main() {
 
   let build_dir = env::current_dir().unwrap().join("../../build/lib").canonicalize().unwrap();
   println!("cargo:rustc-link-search=native={}", build_dir.to_str().unwrap() );
+  println!("cargo:rustc-link-lib=gif");
+  println!("cargo:rustc-link-lib=jpeg");
+  println!("cargo:rustc-link-lib=lcms2");
+  println!("cargo:rustc-link-lib=png16");
+  println!("cargo:rustc-link-lib=simd");
+  println!("cargo:rustc-link-lib=turbojpeg");
+  println!("cargo:rustc-link-lib=z");
 }

--- a/wrappers/server/build.rs
+++ b/wrappers/server/build.rs
@@ -21,6 +21,6 @@ fn main() {
   // Right now we dynamically link... and we fail, because we can't convince cargo 
   // to use a differnt rpath for 'cargo test' 
 
-  let build_dir = env::current_dir().unwrap().join("../../build/").canonicalize().unwrap();
+  let build_dir = env::current_dir().unwrap().join("../../build/lib").canonicalize().unwrap();
   println!("cargo:rustc-link-search=native={}", build_dir.to_str().unwrap() );
 }


### PR DESCRIPTION
- CMake file cleans in build, necessary for clean cmake cache (not cache options like shared)
- Fixed nested build folder
- Now cargo locates the library but there is some problem with imageflow static library, the tests are not passing, there are linking problems.