### PR TITLE
Scopes, Valgrind and more flexible travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - GCC_VERSION=49
     - GCC_VERSION=52
     - GCC_VERSION=53
+    - GCC_VERSION=48 COVERALLS=True
+    - GCC_VERSION=48 VALGRIND=True
+
 
 matrix:
    include:

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -6,10 +6,10 @@ set -x
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     .travis/run_tests.sh
 else
-    if [ ${GCC_VERSION} == 48 ]; then
+    if [ -n "$COVERALLS" ]; then
         # sed -i s/%COVERALLS_TOKEN%/${COVERALLS_TOKEN}/g .travis/proc_coveralls.sh
-        sudo docker run --rm -e "COVERALLS_TOKEN=${COVERALLS_TOKEN}" -v $(pwd):/home/conan lasote/conangcc${GCC_VERSION} /bin/bash -c "sudo pip install conan --upgrade && .travis/run_tests.sh && .travis/proc_coveralls.sh"
+        sudo docker run --rm -e "COVERALLS_TOKEN=${COVERALLS_TOKEN}" -e "VALGRIND=${VALGRIND}" -v $(pwd):/home/conan lasote/conangcc${GCC_VERSION} /bin/bash -c "sudo pip install conan --upgrade && .travis/run_tests.sh && .travis/proc_coveralls.sh"
     else
-        sudo docker run --rm -v $(pwd):/home/conan lasote/conangcc${GCC_VERSION} /bin/bash -c "sudo pip install conan --upgrade && .travis/run_tests.sh"
+        sudo docker run --rm -e "VALGRIND=${VALGRIND}" -v $(pwd):/home/conan lasote/conangcc${GCC_VERSION} /bin/bash -c "sudo pip install conan --upgrade && .travis/run_tests.sh"
     fi
 fi

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -11,5 +11,5 @@ cd bin
 export PATH=$PATH:$(pwd)
 cd ../..
 
-conan install -o build_tests=True -o coverage=True --build missing -u ../
+conan install --scope build_tests=True --scope coverage=True --scope valgrind=${VALGRIND} --build missing -u ../
 conan build ../

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,3 +124,8 @@ if(${CMAKE_GENERATOR} MATCHES "Unix Makefiles")
 	message(STATUS "Added arguments to CMAKE_BUILD_TOOL: ${CMAKE_MAKE_PROGRAM}")
 endif()
 
+
+# VALGRIND INTEGRATION
+find_program( MEMORYCHECK_COMMAND valgrind )
+set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full" )
+# set( MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/valgrind_suppress.txt" )

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Install nasm (`cinst -y nasm` on windows, followed by `set PATH=%PATH%;%ProgramF
  
  
     cd build
-    conan install -u --file ../conanfile.py -o build_tests=True --build missing  -s build_type=Release -s arch=x86_64
+    conan install -u --file ../conanfile.py --scope build_tests=True --build missing  -s build_type=Release -s arch=x86_64
     cd ..
     conan build
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
 test_script:
   - mkdir build
   - cd build
-  - if "%PLATFORM%"=="x86" conan install -o build_tests=True -o shared=True --build missing  -s build_type=Release -s arch=x86 -u ../
-  - if "%PLATFORM%"=="x64" conan install -o build_tests=True -o shared=True --build missing  -s build_type=Release -s arch=x86_64  -u ../
+  - if "%PLATFORM%"=="x86" conan install --scope build_tests=True -o shared=True --build missing -s build_type=Release -s arch=x86 -u ../
+  - if "%PLATFORM%"=="x64" conan install --scope build_tests=True -o shared=True --build missing -s build_type=Release -s arch=x86_64  -u ../
   - conan build ../
   - cd ..
   - conan export lasote/testing

--- a/build_eclipse.sh
+++ b/build_eclipse.sh
@@ -1,7 +1,7 @@
 
  mkdir ../eclipse_imageflow
  cd ../eclipse_imageflow
- conan install -u --file ../imageflow/conanfile.py -o build_tests=False -o profiling=True --build missing
+ conan install -u --file ../imageflow/conanfile.py --scope build_tests=False --scope profiling=True --build missing
  cmake -G"Eclipse CDT4 - Unix Makefiles" -DSKIP_LIBRARY=ON -DENABLE_TEST=OFF -DENABLE_PROFILING=ON ../imageflow
  cmake --build .
  cd ../imageflow

--- a/profile.sh
+++ b/profile.sh
@@ -5,7 +5,7 @@ if [ -d "profiling" ]; then
 else
     mkdir profiling
     cd profiling
-    conan install --file ../conanfile.py -o profiling=True -o build_tests=False --build missing
+    conan install --file ../conanfile.py --scope profiling=True --scope build_tests=False --build missing
 fi
 conan build --file ../conanfile.py
 time build/bin/profile_imageflow

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -19,7 +19,7 @@ rm *~
 
 mkdir -p build
 cd build
-conan install -o build_tests=True --build missing -u ../
+conan install --scope build_tests=True --build missing -u ../
 conan build ../
 
 cd ..


### PR DESCRIPTION
- Conan 0.10.0 has been released today, introduces a new concept of "scope". A scope is just a set of variables that you can set to control your build but that not affect to the final package (nor it's shas). Variables like build_tests or profiling are not options, do not affect to the built artifacts, so I've converted to scope variables.  (The change is easy, in the conanfile you can use self.scope.blablabla, and invoke conan install with --scope variable=value instead of -o)

- I've configured Valgrind too. I've installed and uploaded valgrind in the base docker images and can be activated just with an environment variable VALGRIND

- Following the same way to do the things, I've created the COVERALLS variable to activate the coveralls data upload. 

- In the .travis.yml you will see two new builds in the matrix, but you could use COVERALLS or VALGRIND in some of the existing or combine them, but I think is better to have a specific build for COVERALLS and another for VALGRIND to know if it fails.

- You can see a travis job here: https://travis-ci.org/lasote/imageflow