### PR TITLE
Lock down dependencies for safer cargo update

### DIFF
--- a/imageflow_abi/Cargo.toml
+++ b/imageflow_abi/Cargo.toml
@@ -16,9 +16,9 @@ libc = "0.2"
 imageflow_core = { path = "../imageflow_core", version = "*" }
 backtrace = "*"
 smallvec="*"
-base64="*"
+base64="0.5"
 
 [build-dependencies]
 imageflow_helpers = { path = "../imageflow_helpers", version = "*" }
 moz-cheddar = "0.4.1"
-regex = "*"
+regex = "0.2"

--- a/imageflow_core/Cargo.toml
+++ b/imageflow_core/Cargo.toml
@@ -16,14 +16,14 @@ libc = "0.2"
 num = "0.1"
 
 # time
-time = "*"
+time = "0.1"
 chrono =  "0.4"
 
 # serialization
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
-rustc-serialize = "*"
+serde = "1"
+serde_json = "1"
+serde_derive = "1"
+rustc-serialize = "0.3"
 
 #lazy static
 lazy_static = "0.2"
@@ -31,7 +31,7 @@ lazy_static = "0.2"
 # fast hashes, crypto hashs
 twox-hash = "1"
 fnv = "*"
-blake2-rfc = "*"
+blake2-rfc = "0.2"
 
 ## Crate-specific dependencies
 
@@ -45,11 +45,11 @@ smallvec = "*"
 gif = "*"
 rgb = "0.7"
 
-lcms2 = { git = "https://github.com/pornel/rust-lcms2.git", rev = "e0bd98cdd1b1269848bfde92ec098d22fc0a8a32" }
+lcms2 = "5.0"
 lcms2-sys = {version="*", default-features = false}
-chashmap = "*"
+chashmap = "2.2"
 
-url = "*"
+url = "1.4"
 uuid = { version = "0.5", features = ["v4"] }
 
 imageflow_types = { path = "../imageflow_types", version = "*" }
@@ -58,7 +58,7 @@ imageflow_riapi = { path = "../imageflow_riapi", version = "*" }
 
 
 [dev-dependencies]
-hyper = { version = "*" }
+hyper = "=0.10.12"
 
 
 [build-dependencies]

--- a/imageflow_helpers/Cargo.toml
+++ b/imageflow_helpers/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "*", features= ["v4", "v5"]}
 lockless = "*"
 smallvec = "*"
 # regex
-regex = "*"
+regex = "0.2"
 
 num = "*"
 
@@ -42,17 +42,16 @@ zip = { version = "0.2", default-features = false }
 
 
 app_dirs = "^1.1.1"
-chashmap = "*"
+chashmap = "2.2"
 parking_lot = {version = "0.4", features = ["nightly"]}
-
 
 unicase = "2"
 # HTTPS is a little bit of a nightmare
 
 error-chain = "*"
 
-hyper = "*"
-reqwest = "*"
+hyper = "=0.10.12"
+reqwest = "0.6"
 hyper-native-tls = "*"
 
 backtrace = "0.3.2"

--- a/imageflow_riapi/Cargo.toml
+++ b/imageflow_riapi/Cargo.toml
@@ -8,7 +8,7 @@ workspace = "../"
 imageflow_types = { path = "../imageflow_types", version = "*" }
 imageflow_helpers = { path = "../imageflow_helpers", version = "*" }
 url = "*"
-ieee754 ="*"
+ieee754 ="0.2"
 time="*"
 macro-attr= { git="https://github.com/DanielKeep/rust-custom-derive.git"}
 enum_derive= { git="https://github.com/DanielKeep/rust-custom-derive.git" }

--- a/imageflow_server/Cargo.toml
+++ b/imageflow_server/Cargo.toml
@@ -10,13 +10,13 @@ workspace = "../"
 libc = "0.2"
 
 # time
-time = "*"
+time = "0.1"
 chrono =  "0.4"
 
 # serialization
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
+serde = "1"
+serde_json = "1"
+serde_derive = "1"
 rustc-serialize = "*"
 
 #lazy static
@@ -32,11 +32,11 @@ blake2-rfc = "*"
 
 clap = "2"
 
-router = "*"
-iron = "*"
+router = "0.5"
+iron = "=0.5.1"
 
 
-hyper = { version = "*", default-features = false }
+hyper = { version = "=0.10.12", default-features = false }
 threadpool = "1.0"
 
 imageflow_core = { path = "../imageflow_core", version = "*" }
@@ -45,19 +45,19 @@ imageflow_helpers = { path = "../imageflow_helpers", version = "*" }
 imageflow_riapi = { path = "../imageflow_riapi", version = "*" }
 
 
-rand = "*"
-lru-cache = "*"
-persistent = "*"
+rand = "0.3"
+lru-cache = "0.1"
+persistent = "0.3"
 regex = "0.2"
-log="*"
-env_logger="*"
+log="0.3"
+env_logger="0.4"
 wait-timeout = "0.1"
 bincode= {git= "https://github.com/TyOverby/bincode" }
 staticfile = { git= "https://github.com/onur/staticfile", rev= "9f2ff7201eda648128c92e3f5597c587f0629f51" }
-conduit-mime-types = "*"
-url="*"
-hyper-native-tls="*"
-reqwest="*"
+conduit-mime-types = "0.7"
+url="1.4"
+hyper-native-tls="0.2"
+reqwest="0.6"
 
 [build-dependencies]
 cmake = "0.1.17"
@@ -68,9 +68,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies.mount]
-
 git = "https://github.com/iron/mount.git"
+rev = "2c3d719be4c158d4ddbd8cdb402fafccdefec58c"
 
 [dependencies.logger]
-
 git = "https://github.com/iron/logger.git"
+rev = "0daead5fe10c3cd0c4738767c162dc63a59c3fb3"

--- a/imageflow_tool/Cargo.toml
+++ b/imageflow_tool/Cargo.toml
@@ -9,11 +9,11 @@ imageflow_core = { path = "../imageflow_core", version = "*" }
 imageflow_types = { path = "../imageflow_types", version = "*" }
 libc = "0.2.0"
 clap = "2"
-time = "*"
+time = "0.1"
 rustc-serialize = "*"
 threadpool = "1"
-serde = "*"
-serde_json = "*"
+serde = "1"
+serde_json = "1"
 imageflow_helpers = { path = "../imageflow_helpers", version = "*" }
 
 [[bin]]

--- a/imageflow_types/Cargo.toml
+++ b/imageflow_types/Cargo.toml
@@ -10,14 +10,14 @@ name="imageflow_types"
 doctest = false
 
 [dependencies]
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
-lazy_static = "*"
-regex = "*"
+serde = "1"
+serde_json = "1"
+serde_derive = "1"
+lazy_static = "0.2"
+regex = "0.2"
 imageflow_helpers = { path = "../imageflow_helpers", version = "*" }
-chrono ="*"
+chrono = "0.4"
 
 [build-dependencies]
 quick-error = "1"
-chrono =  "0.4"
+chrono = "0.4"


### PR DESCRIPTION
Currently the build holds together only thanks to the lock file, but this means that addition of new dependencies may require cargo update, and dealing with the fallout of other unexpected upgrades.

If you'd like to track latest versions of deps, I recommend checking [`cargo-update`](https://github.com/nabijaczleweli/cargo-update).
