### PR TITLE
Fix bash constant comparison in Travis scripts

### DIFF
--- a/ci/travis_run_docker.sh
+++ b/ci/travis_run_docker.sh
@@ -22,7 +22,7 @@ fi
 ./build.sh
 test -d target/doc && chmod a+rwX target/doc # travis cache process can't delete it otherwise
 
-if [[ "SKIP_HOST_CARGO_EXPORT" != 'True' ]]; then
+if [[ "$SKIP_HOST_CARGO_EXPORT" != 'True' ]]; then
     if [[ -d "${HOME}/.cargo/git" && -d "${HOME}/.cargo/registry" ]]; then
         echo "exporting registry to host_cargo"
         cp -Rp "${HOME}/.cargo/git" "${HOME}/host_cargo/git"


### PR DESCRIPTION
Fixes a mistaken comparison of a constant string against `True` when the
desired behavior is comparing the variable "$SKIP_HOST_CARGO_EXPORT"
against `True`.

This was pointed out by shellcheck while trying to compile project from
scratch.

Fixing this expression unblocked compilation on MacOS.

PS - Thank you for working on this project, it's exciting to try it out :).