### PR TITLE
Skip alloca.h on FreeBSD

### DIFF
--- a/c_components/lib/graphics.c
+++ b/c_components/lib/graphics.c
@@ -26,8 +26,16 @@
 #include <string.h>
 #include <immintrin.h>
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#ifndef __BSD__
+#define __BSD__
+#endif
+#endif
+
 #ifndef _MSC_VER
+#ifndef __BSD__
 #include <alloca.h>
+#endif
 #else
 #pragma unmanaged
 #ifndef alloca


### PR DESCRIPTION
alloc(3) is part of libc on FreeBSD
https://man.freebsd.org/alloca

FWIW it's also part of libc on https://man.openbsd.org/alloca & https://man.netbsd.org/alloca.3 perhaps we can include all of those here too?