### PR TITLE
.rustfmt.toml: Fix invalid TOML

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,7 +2,7 @@ max_width=120
 use_small_heuristics="Max"
 newline_style="Unix"
 fn_args_layout="Compressed"
-group_imports = StdExternalCrate
+group_imports = "StdExternalCrate"
 
 # Once these stabilize, they'd be nice
 # indent_style="Visual"


### PR DESCRIPTION
Fixes this error when running `rustfmt` or `cargo fmt`:

    Could not parse TOML: TOML parse error at line 5, column 17
      |
    5 | group_imports = StdExternalCrate
      |                 ^
    invalid string
    expected `"`, `'`