### PR TITLE
transpose: Fix invalid_reference_casting errors

### DIFF
--- a/imageflow_core/src/graphics/transpose.rs
+++ b/imageflow_core/src/graphics/transpose.rs
@@ -119,14 +119,13 @@ pub unsafe fn flow_bitmap_bgra_transpose(
     while x < (*to).w {
         let mut y: u32 = 0 as i32 as u32;
         while y < (*to).h {
-            *(&mut *(*to).pixels.offset(
+            *((*to).pixels.offset(
                 x.wrapping_mul(4u32)
                     .wrapping_add(y.wrapping_mul((*to).stride)) as isize,
-            ) as *mut libc::c_uchar as *mut u32) = *(&mut *(*from).pixels.offset(
+            ) as *mut u32) = *((*from).pixels.offset(
                 x.wrapping_mul((*from).stride)
                     .wrapping_add(y.wrapping_mul(4u32)) as isize,
-            ) as *mut libc::c_uchar
-                as *mut u32);
+            ) as *mut u32);
             y = y.wrapping_add(1)
         }
         x = x.wrapping_add(1)
@@ -135,14 +134,13 @@ pub unsafe fn flow_bitmap_bgra_transpose(
     while x_0 < cropped_h as u32 {
         let mut y_0: u32 = cropped_w as u32;
         while y_0 < (*to).h {
-            *(&mut *(*to).pixels.offset(
+            *((*to).pixels.offset(
                 x_0.wrapping_mul(4u32)
                     .wrapping_add(y_0.wrapping_mul((*to).stride)) as isize,
-            ) as *mut libc::c_uchar as *mut u32) = *(&mut *(*from).pixels.offset(
+            ) as *mut u32) = *((*from).pixels.offset(
                 x_0.wrapping_mul((*from).stride)
                     .wrapping_add(y_0.wrapping_mul(4u32)) as isize,
-            ) as *mut libc::c_uchar
-                as *mut u32);
+            ) as *mut u32);
             y_0 = y_0.wrapping_add(1)
         }
         x_0 = x_0.wrapping_add(1)
@@ -164,14 +162,13 @@ unsafe fn flow_bitmap_bgra_transpose_slow(
         while x < (*to).w {
             let mut y: u32 = 0 as i32 as u32;
             while y < (*to).h {
-                *(&mut *(*to).pixels.offset(
+                *((*to).pixels.offset(
                     x.wrapping_mul(4u32)
                         .wrapping_add(y.wrapping_mul((*to).stride)) as isize,
-                ) as *mut libc::c_uchar as *mut u32) = *(&mut *(*from).pixels.offset(
+                ) as *mut u32) = *((*from).pixels.offset(
                     x.wrapping_mul((*from).stride)
                         .wrapping_add(y.wrapping_mul(4u32)) as isize,
-                ) as *mut libc::c_uchar
-                    as *mut u32);
+                ) as *mut u32);
                 y = y.wrapping_add(1)
             }
             x = x.wrapping_add(1)


### PR DESCRIPTION
Fixes this build error with current Rust nightly:

    error: casting references to a bigger memory layout than the backing allocation is undefined behavior, even if the reference is unused
       --> imageflow_core/src/graphics/transpose.rs:122:13
        |
    122 |                *(&mut *(*to).pixels.offset(
        |   _____________^______-
        |  |_____________|
        | ||
    123 | ||                 x.wrapping_mul(4u32)
    124 | ||                     .wrapping_add(y.wrapping_mul((*to).stride)) as isize,
    125 | ||             ) as *mut libc::c_uchar as *mut u32) = *(&mut *(*from).pixels.offset(
        | ||_____________- backing allocation comes from here
    ...   |
    128 | |              ) as *mut libc::c_uchar
    129 | |                  as *mut u32);
        | |_____________________________^
        |
        = note: casting from `u8` (1 bytes) to `u32` (4 bytes)
        = note: `#[deny(invalid_reference_casting)]` on by default